### PR TITLE
Publish msg even when first fold

### DIFF
--- a/tests/interface/dealer_test.py
+++ b/tests/interface/dealer_test.py
@@ -1,4 +1,5 @@
 from tests.base_unittest import BaseUnitTest
+from tests.record_player import PokerPlayer as RecordMan
 from mock import patch
 from pypokerengine.interface.dealer import Dealer
 from pypokerengine.players.sample.fold_man import PokerPlayer as FoldMan
@@ -18,6 +19,33 @@ class DealerTest(BaseUnitTest):
       self.eq("hoge", player.name)
       self.eq(100, player.stack)
       self.eq(algo, self.mh.algo_owner_map["a"])
+
+  def test_publish_msg(self):
+    self.dealer = Dealer(1, 100)
+    self.mh = self.dealer.message_handler
+    algos = [RecordMan() for _ in range(2)]
+    [self.dealer.register_player(name, algo) for name, algo in zip(["hoge", "fuga"], algos)]
+    players = self.dealer.table.seats.players
+    _ = self.dealer.start_game(1)
+
+    first_player_expected = [
+        "receive_round_start_message",
+        "receive_street_start_message",
+        "declare_action",
+        "receive_game_update_message",
+        "receive_round_result_message"
+        ]
+    second_player_expected = [
+        "receive_round_start_message",
+        "receive_street_start_message",
+        "receive_game_update_message",
+        "receive_round_result_message"
+        ]
+
+    for i, expected in enumerate(first_player_expected):
+      self.eq(expected, algos[0].received_msgs[i])
+    for i, expected in enumerate(second_player_expected):
+      self.eq(expected, algos[1].received_msgs[i])
 
   def test_play_a_round(self):
     algos = [FoldMan() for _ in range(2)]

--- a/tests/record_player.py
+++ b/tests/record_player.py
@@ -1,0 +1,29 @@
+from pypokerengine.players.sample.fold_man import PokerPlayer as FoldMan
+
+class PokerPlayer(FoldMan):
+
+  def __init__(self):
+    self.received_msgs = []
+
+  def declare_action(self, hole_card, valid_actions, round_state, action_histories):
+    self.received_msgs.append("declare_action")
+    return 'fold', 0
+
+  def receive_game_start_message(self, game_info):
+    self.received_msgs.append("receive_game_start_message")
+
+  def receive_round_start_message(self, hole_card, seats):
+    self.received_msgs.append("receive_round_start_message")
+
+  def receive_street_start_message(self, street, round_state):
+    self.received_msgs.append("receive_street_start_message")
+
+  def receive_game_update_message(self, action, round_state, action_histories):
+    self.received_msgs.append("receive_game_update_message")
+
+  def receive_round_result_message(self, winners, round_state):
+    self.received_msgs.append("receive_round_result_message")
+
+  def receive_game_result_message(self, seats):
+    self.received_msgs.append("receive_game_result_message")
+


### PR DESCRIPTION
### やった
round_resultメッセージとその付近のメッセージが送られないバグの修正

### 再現手順
1. `RoundManager. start_new_round ` or `RoundManager.apply_action`でplayerが`fold`
2. 1のそれぞれのメソッドの戻り値`msgs`に`game_update`,`round_result`とかが入る
3. `dealer.__play_round`のwhileループの継続条件を満たさないため,**`dealer.__publish_messages`が呼ばれず**に`dealer.__prepare_for_next_round`が行われてしまう

### 修正
- メッセージをpublishしてから，ループを抜ける判定を行うようにして，送られないメッセージがないようにする.