### PR TITLE
Fix draw judge

### DIFF
--- a/pypokerengine/engine/hand_evaluator.py
+++ b/pypokerengine/engine/hand_evaluator.py
@@ -27,11 +27,24 @@ class HandEvaluator:
   @classmethod
   def gen_hand_rank_info(self, hole, community):
     hand = self.eval_hand(hole, community)
-    row_strength = self.__mask_strength(hand)
+    row_strength = self.__mask_hand_strength(hand)
     strength = self.HAND_STRENGTH_MAP[row_strength]
-    high = self.__high_rank(hand)
-    low = self.__low_rank(hand)
-    return { "strength" : strength, "high" : high, "low" : low }
+    hand_high = self.__mask_hand_high_rank(hand)
+    hand_low = self.__mask_hand_low_rank(hand)
+    hole_high = self.__mask_hole_high_rank(hand)
+    hole_low = self.__mask_hole_low_rank(hand)
+
+    return {
+        "hand" : {
+          "strength" : strength,
+          "high" : hand_high,
+          "low" : hand_low
+        },
+        "hole" : {
+          "high" : hole_high,
+          "low" : hole_low
+        }
+    }
 
   @classmethod
   def eval_hand(self, hole, community):
@@ -220,17 +233,27 @@ class HandEvaluator:
     return self.__search_straight(flash_cards)
 
   @classmethod
-  def __mask_strength(self, bit):
+  def __mask_hand_strength(self, bit):
     mask = 511 << 16
     return (bit & mask) >> 8  # 511 = (1 << 9) -1
 
   @classmethod
-  def __high_rank(self, bit):
+  def __mask_hand_high_rank(self, bit):
     mask = 15 << 12
     return (bit & mask) >> 12
 
   @classmethod
-  def __low_rank(self, bit):
+  def __mask_hand_low_rank(self, bit):
     mask = 15 << 8
     return (bit & mask) >> 8
+
+  @classmethod
+  def __mask_hole_high_rank(self, bit):
+    mask = 15 << 4
+    return (bit & mask) >> 4
+
+  @classmethod
+  def __mask_hole_low_rank(self, bit):
+    mask = 15
+    return bit & mask
 

--- a/pypokerengine/engine/hand_evaluator.py
+++ b/pypokerengine/engine/hand_evaluator.py
@@ -55,7 +55,7 @@ class HandEvaluator:
     if self.__is_straight(cards): return self.STRAIGHT | self.__eval_straight(cards)
     if self.__is_threecard(cards): return self.THREECARD | self.__eval_threecard(cards)
     if self.__is_twopair(cards): return self.TWOPAIR | self.__eval_twopair(cards)
-    if self.__is_onepair(cards): return self.ONEPAIR | (self.__eval_onepair(cards) << 4)
+    if self.__is_onepair(cards): return self.ONEPAIR | (self.__eval_onepair(cards))
     return self.__eval_holecard(hole)
 
   @classmethod
@@ -65,17 +65,17 @@ class HandEvaluator:
 
   @classmethod
   def __is_onepair(self, cards):
-    return self.__eval_onepair(cards) != -1
+    return self.__eval_onepair(cards) != 0
 
   @classmethod
   def __eval_onepair(self, cards):
-    rank = -1
+    rank = 0
     memo = 0  # bit memo
     for card in cards:
       mask = 1 << card.rank
       if memo & mask != 0: rank = max(rank, card.rank)
       memo |= mask
-    return rank
+    return rank << 4
 
   @classmethod
   def __is_twopair(self, cards):

--- a/pypokerengine/engine/hand_evaluator.py
+++ b/pypokerengine/engine/hand_evaluator.py
@@ -33,6 +33,13 @@ class HandEvaluator:
     low = self.__low_rank(hand)
     return { "strength" : strength, "high" : high, "low" : low }
 
+  @classmethod
+  def eval_hand(self, hole, community):
+    ranks = sorted([card.rank for card in hole])
+    hole_flg = ranks[1] << 4 | ranks[0]
+    hand_flg = self.__calc_hand_info_flg(hole, community) << 8
+    return hand_flg | hole_flg
+
   # Return Format
   # [Bit flg of hand][rank1(4bit)][rank2(4bit)]
   # ex.)
@@ -46,7 +53,7 @@ class HandEvaluator:
   #       FourCard of rank 2       =>  1000000 0010 0000
   #       straight flash of rank 7 => 10000000 0111 0000
   @classmethod
-  def eval_hand(self, hole, community):
+  def __calc_hand_info_flg(self, hole, community):
     cards = hole + community
     if self.__is_straightflash(cards): return self.STRAIGHTFLASH | self.__eval_straightflash(cards)
     if self.__is_fourcard(cards): return self.FOURCARD | self.__eval_fourcard(cards)
@@ -214,15 +221,16 @@ class HandEvaluator:
 
   @classmethod
   def __mask_strength(self, bit):
-    return bit & (511 << 8)  # 511 = (1 << 9) -1
+    mask = 511 << 16
+    return (bit & mask) >> 8  # 511 = (1 << 9) -1
 
   @classmethod
   def __high_rank(self, bit):
-    mask = 15 << 4
-    return (bit & 240) >> 4
+    mask = 15 << 12
+    return (bit & mask) >> 12
 
   @classmethod
   def __low_rank(self, bit):
-    mask = 15
-    return bit & mask
+    mask = 15 << 8
+    return (bit & mask) >> 8
 

--- a/pypokerengine/players/console_writer.py
+++ b/pypokerengine/players/console_writer.py
@@ -74,7 +74,7 @@ class ConsoleWriter:
     print '-- winners --'
     for winner in winners:
       print ' %s' % self.write_base_player(winner)
-    print ' ( hands = %s )' % hand_info
+    self.write_hand_info(hand_info)
     print '-- round state --'
     print ' Street : %s' % round_state['street']
     print ' Community Card : %s' % round_state['community_card']
@@ -97,6 +97,14 @@ class ConsoleWriter:
     if len(batch)!=0:
       base_str = "%s <= %s" % (base_str, batch)
     return base_str
+
+  def write_hand_info(self, hand_info):
+    if len(hand_info) != 0: print '-- hand info --'
+    for info in hand_info:
+      hand, hole = info["hand"]["hand"], info["hand"]["hole"]
+      print "player [%s]" % info["uuid"]
+      print "  hand => %s (high=%d, low=%d)" % (hand["strength"], hand["high"], hand["low"])
+      print "  hole => [%s, %s]" % (hole["high"], hole["low"])
 
   def __is_next_player(self, player, round_state):
     return round_state and player == round_state["seats"][round_state["next_player"]]

--- a/tests/engine/game_evaluator_test.py
+++ b/tests/engine/game_evaluator_test.py
@@ -29,8 +29,8 @@ class GameEvaluatorTest(BaseUnitTest):
     with patch('pypokerengine.engine.hand_evaluator.HandEvaluator.eval_hand', side_effect=mock_eval_hand_return):
       winner, hand_info, prize_map = GameEvaluator.judge(table)
       self.eq(2, len(winner))
-      self.eq("HIGHCARD", hand_info[0]["hand"]["strength"])
-      self.eq("HIGHCARD", hand_info[1]["hand"]["strength"])
+      self.eq("HIGHCARD", hand_info[0]["hand"]["hand"]["strength"])
+      self.eq("HIGHCARD", hand_info[1]["hand"]["hand"]["strength"])
       self.eq(7, prize_map[0])
       self.eq(0, prize_map[1])
       self.eq(7, prize_map[2])
@@ -42,9 +42,9 @@ class GameEvaluatorTest(BaseUnitTest):
     mock_eval_hand_return = [0,2,1]*6
     with patch('pypokerengine.engine.hand_evaluator.HandEvaluator.eval_hand', side_effect=mock_eval_hand_return):
       winner, hand_info, prize_map = GameEvaluator.judge(table)
-      self.eq(0, hand_info[0]["hand"]["low"])
-      self.eq(2, hand_info[1]["hand"]["low"])
-      self.eq(1, hand_info[2]["hand"]["low"])
+      self.eq(0, hand_info[0]["hand"]["hole"]["low"])
+      self.eq(2, hand_info[1]["hand"]["hole"]["low"])
+      self.eq(1, hand_info[2]["hand"]["hole"]["low"])
       self.eq(20, prize_map[0])
       self.eq(60, prize_map[1])
       self.eq(20, prize_map[2])
@@ -56,9 +56,9 @@ class GameEvaluatorTest(BaseUnitTest):
     mock_eval_hand_return = [1,2,0]*3 + [1,0] + [0]
     with patch('pypokerengine.engine.hand_evaluator.HandEvaluator.eval_hand', side_effect=mock_eval_hand_return):
       winner, hand_info, prize_map = GameEvaluator.judge(table)
-      self.eq(1, hand_info[0]["hand"]["low"])
-      self.eq(2, hand_info[1]["hand"]["low"])
-      self.eq(0, hand_info[2]["hand"]["low"])
+      self.eq(1, hand_info[0]["hand"]["hole"]["low"])
+      self.eq(2, hand_info[1]["hand"]["hole"]["low"])
+      self.eq(0, hand_info[2]["hand"]["hole"]["low"])
       self.eq(40, prize_map[0])
       self.eq(60, prize_map[1])
       self.eq(0, prize_map[2])
@@ -69,9 +69,9 @@ class GameEvaluatorTest(BaseUnitTest):
     mock_eval_hand_return = [2,1,0]*3 + [2,0] + [2]
     with patch('pypokerengine.engine.hand_evaluator.HandEvaluator.eval_hand', side_effect=mock_eval_hand_return):
       winner, hand_info, prize_map = GameEvaluator.judge(table)
-      self.eq(2, hand_info[0]["hand"]["low"])
-      self.eq(1, hand_info[1]["hand"]["low"])
-      self.eq(0, hand_info[2]["hand"]["low"])
+      self.eq(2, hand_info[0]["hand"]["hole"]["low"])
+      self.eq(1, hand_info[1]["hand"]["hole"]["low"])
+      self.eq(0, hand_info[2]["hand"]["hole"]["low"])
       self.eq(100, prize_map[0])
       self.eq(0, prize_map[1])
       self.eq(0, prize_map[2])

--- a/tests/engine/hand_evaluator_test.py
+++ b/tests/engine/hand_evaluator_test.py
@@ -17,9 +17,11 @@ class HandEvaluatorTest(BaseUnitTest):
         Card(Card.DIAMOND, 2)
     ]
     info = HandEvaluator.gen_hand_rank_info(hole, community)
-    self.eq("HIGHCARD", info["strength"])
-    self.eq(9, info["high"])
-    self.eq(2, info["low"])
+    self.eq("HIGHCARD", info["hand"]["strength"])
+    self.eq(9, info["hand"]["high"])
+    self.eq(2, info["hand"]["low"])
+    self.eq(9, info["hole"]["high"])
+    self.eq(2, info["hole"]["low"])
 
   def test_eval_high_card(self):
     community = [
@@ -35,9 +37,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.HIGHCARD, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(9, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(2, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.HIGHCARD, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(9, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(2, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(9, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(2, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_onepair(self):
     community = [
@@ -53,9 +57,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.ONEPAIR, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(3, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(0, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.ONEPAIR, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(0, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(9, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_twopair(self):
     community = [
@@ -71,9 +77,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.TWOPAIR, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(9, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(3, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.TWOPAIR, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(9, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(9, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_threecard(self):
     community = [
@@ -89,9 +97,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.THREECARD, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(3, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(0, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.THREECARD, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(0, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(9, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_straight(self):
     community = [
@@ -107,9 +117,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.STRAIGHT, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(3, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(0, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.STRAIGHT, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(0, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(5, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(4, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_flash(self):
     community = [
@@ -125,9 +137,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.FLASH, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(6, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(0, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.FLASH, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(6, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(0, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(5, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(4, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_fullhouse(self):
     community = [
@@ -143,9 +157,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.FULLHOUSE, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(4, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(5, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.FULLHOUSE, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(4, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(5, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(5, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(4, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_fullhouse2(self):
     community = [
@@ -162,9 +178,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.FULLHOUSE, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(7, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(3, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.FULLHOUSE, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(7, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(8, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(7, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_fourcard(self):
     community = [
@@ -181,9 +199,11 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.FOURCARD, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(3, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(0, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.FOURCARD, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(0, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(8, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(3, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 
   def test_straightflash(self):
     community = [
@@ -199,7 +219,9 @@ class HandEvaluatorTest(BaseUnitTest):
         ]
 
     bit = HandEvaluator.eval_hand(hole, community)
-    self.eq(HandEvaluator.STRAIGHTFLASH, HandEvaluator._HandEvaluator__mask_strength(bit))
-    self.eq(10, HandEvaluator._HandEvaluator__high_rank(bit))
-    self.eq(0, HandEvaluator._HandEvaluator__low_rank(bit))
+    self.eq(HandEvaluator.STRAIGHTFLASH, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(10, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(0, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+    self.eq(14, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
+    self.eq(10, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
 


### PR DESCRIPTION
手の強さの判定時にkikcerを見ないので，引き分けが起こりやすい.
kicker無視はゲームの戦略に関わってしまうので，修正．

手の強さを表すflgの下位8bitにhole cardのrankを追加して，
kikcerを考慮するように修正

### ex. 2,9のhigh card
Before
```
(Pdb) bin(HandEvaluator.eval_hand(hole, community))
'0b10010010'
```
After
```
(Pdb) bin(HandEvaluator.eval_hand(hole, community))
'0b1001001010010010'
```