### PR TITLE
Fix msg timing

### DIFF
--- a/pypokerengine/engine/round_manager.py
+++ b/pypokerengine/engine/round_manager.py
@@ -100,9 +100,9 @@ class RoundManager:
   def __showdown(self, state):
     winners, hand_info, prize_map = GameEvaluator.judge(state["table"])
     self.__prize_to_winners(state["table"].seats.players, prize_map)
+    result_message = MessageBuilder.build_round_result_message(state["round_count"], winners, hand_info, state)
     state["table"].reset()
     state["street"] += 1
-    result_message = MessageBuilder.build_round_result_message(state["round_count"], winners, hand_info, state)
     return state, [(-1, result_message)]
 
   @classmethod

--- a/pypokerengine/players/console_writer.py
+++ b/pypokerengine/players/console_writer.py
@@ -82,7 +82,9 @@ class ConsoleWriter:
     print ' Dealer Btn : %s ' % round_state['seats'][round_state['dealer_btn']]['name']
     print ' Players'
     for position, player in enumerate(round_state['seats']):
-      print ' %d : %s' % (position, self.write_player(player, round_state))
+      player_str = self.write_player(player, round_state)
+      player_str = player_str.replace(", NEXT", "")
+      print ' %d : %s' % (position, player_str)
     print '=============================================='
 
   def write_base_player(self, p):


### PR DESCRIPTION
Round result をtableがリセットされる前に送るように修正

Before
```
 -- Round Result (UUID = usisevfesakhqunfrlvibr) --
==============================================
-- winners --
 player1 (pwijqlssbdinjzdkytovul) => state : participating, stack : 125
 player2 (usisevfesakhqunfrlvibr) => state : participating, stack : 75
 ( hands = [{'uuid': 'pwijqlssbdinjzdkytovul', 'hand': {'high': 9, 'strength': 'ONEPAIR', 'low': 0}}, {'uuid': 'usisevfesakhqunfrlvibr', 'hand': {'high': 9, 'strength': 'ONEPAIR', 'low': 0}}] )
-- round state --
 Street : None
 Community Card : []
 Pot : main = 0, side = []
 Dealer Btn : player2 
 Players
 0 : player1 (pwijqlssbdinjzdkytovul) => state : participating, stack : 125 <= BB
 1 : player2 (usisevfesakhqunfrlvibr) => state : participating, stack : 75 <= SB, NEXT
==============================================
```

After
```
 -- Round Result (UUID = owakqlquliivhhyhyfntrg) --
==============================================
-- winners --
 player2 (mpmklekyswedqvblpastvf) => state : participating, stack : 150
-- hand info --
player [owakqlquliivhhyhyfntrg]
  hand => ONEPAIR (high=10, low=0)
  hole => [11, 10]
player [mpmklekyswedqvblpastvf]
  hand => ONEPAIR (high=13, low=0)
  hole => [13, 6]
-- round state --
 Street : showdown
 Community Card : ['SK', 'D7', 'CT', 'HQ', 'S3']
 Pot : main = 40, side = []
 Dealer Btn : player2 
 Players
 0 : player1 (owakqlquliivhhyhyfntrg) => state : participating, stack : 50 <= BB
 1 : player2 (mpmklekyswedqvblpastvf) => state : participating, stack : 150 <= SB
==============================================
```