### PR TITLE
Tweak for emulator

### DIFF
--- a/examples/players/console_player.py
+++ b/examples/players/console_player.py
@@ -24,7 +24,7 @@ class PokerPlayer(BasePokerPlayer):
     self.__wait_until_input()
 
   def receive_game_update_message(self, new_action, round_state):
-    self.writer.write_game_update_message(new_action, round_state, action_histories)
+    self.writer.write_game_update_message(new_action, round_state)
     self.__wait_until_input()
 
   def receive_round_result_message(self, winners, hand_info, round_state):

--- a/examples/players/console_player.py
+++ b/examples/players/console_player.py
@@ -97,8 +97,14 @@ class ConsoleWriter:
       player_str = player_str.replace("NEXT", "CURRENT")
       print ' %d : %s' % (position, player_str)
     print '-- action histories --'
-    for action in round_state["action_histories"]:
-      print ' %s' % action
+    fetch_name = lambda uuid: [player["name"] for player in round_state["seats"] if player["uuid"]==uuid][0]
+    for street, histories in round_state["action_histories"].iteritems():
+      if len(histories) != 0:
+        print "  %s" % street
+        for history in histories:
+          uuid = history.pop("uuid")
+          history["player"] = "%s (uuid=%s)" % (fetch_name(uuid), uuid)
+          print "    %s" % history
     print '=============================================='
 
   def write_game_start_message(self, game_info):

--- a/examples/players/console_player.py
+++ b/examples/players/console_player.py
@@ -98,10 +98,12 @@ class ConsoleWriter:
       print ' %d : %s' % (position, player_str)
     print '-- action histories --'
     fetch_name = lambda uuid: [player["name"] for player in round_state["seats"] if player["uuid"]==uuid][0]
-    for street, histories in round_state["action_histories"].iteritems():
+    sort_key = lambda e: {"preflop":0, "flop":1, "turn":2, "river":3}[e[0]]
+    for street, histories in sorted(round_state["action_histories"].iteritems(), key=sort_key):
       if len(histories) != 0:
         print "  %s" % street
-        for history in histories:
+        for original in histories:
+          history = {k:v for k,v in original.iteritems()}
           uuid = history.pop("uuid")
           history["player"] = "%s (uuid=%s)" % (fetch_name(uuid), uuid)
           print "    %s" % history

--- a/pypokerengine/engine/card.py
+++ b/pypokerengine/engine/card.py
@@ -60,4 +60,11 @@ class Card:
 
     return cls(suit, rank)
 
+  @classmethod
+  def from_str(cls, str_card):
+    assert(len(str_card)==2)
+    inverse = lambda hsh: {v:k for k,v in hsh.iteritems()}
+    suit = inverse(cls.SUIT_MAP)[str_card[0].upper()]
+    rank = inverse(cls.RANK_MAP)[str_card[1]]
+    return cls(suit, rank)
 

--- a/pypokerengine/engine/data_encoder.py
+++ b/pypokerengine/engine/data_encoder.py
@@ -85,9 +85,9 @@ class DataEncoder:
         "dealer_btn": state["table"].dealer_btn,
         "next_player": state["next_player"],
         "round_count": state["round_count"],
-        "action_histories": self.encode_action_histories(state["table"])
     }
     hsh.update(self.encode_seats(state["table"].seats))
+    hsh.update(self.encode_action_histories(state["table"]))
     return hsh
 
 

--- a/pypokerengine/engine/player.py
+++ b/pypokerengine/engine/player.py
@@ -10,6 +10,7 @@ class Player:
     self.uuid = uuid
     self.hole_card = []
     self.stack = initial_stack
+    self.round_action_histories = self.__init_round_action_histories()
     self.action_histories = []
     self.pay_info = PayInfo()
 
@@ -53,7 +54,12 @@ class Player:
     history = self.__add_uuid_on_history(history)
     self.action_histories.append(history)
 
+  def save_street_action_histories(self, street_flg):
+    self.round_action_histories[street_flg] = self.action_histories
+    self.action_histories = []
+
   def clear_action_histories(self):
+    self.round_action_histories = self.__init_round_action_histories()
     self.action_histories = []
 
   def clear_pay_info(self):
@@ -68,7 +74,7 @@ class Player:
     hole = [card.to_id() for card in self.hole_card]
     return [
         self.name, self.uuid, self.stack, hole,\
-            self.action_histories[::], self.pay_info.serialize()
+            self.action_histories[::], self.pay_info.serialize(), self.round_action_histories[::]
     ]
 
   @classmethod
@@ -78,6 +84,7 @@ class Player:
     if len(hole)!=0: player.add_holecard(hole)
     player.action_histories = serial[4]
     player.pay_info = PayInfo.deserialize(serial[5])
+    player.round_action_histories = serial[6]
     return player
 
   """ private """
@@ -86,6 +93,9 @@ class Player:
   __wrong_num_hole_msg = "You passed  %d hole cards"
   __wrong_type_hole_msg = "You passed not Card object as hole card"
   __collect_err_msg = "Failed to collect %d chips. Because he has only %d chips"
+
+  def __init_round_action_histories(self):
+    return [None for _ in range(4)]  # 4 == len(["preflop", "flop", "turn", "river"])
 
   def __fold_history(self):
     return { "action" : "FOLD" }

--- a/pypokerengine/engine/round_manager.py
+++ b/pypokerengine/engine/round_manager.py
@@ -26,8 +26,8 @@ class RoundManager:
     state = self.__update_state_by_action(state, action, bet_amount)
     update_msg = self.__update_message(state, action, bet_amount)
     if self.__is_everyone_agreed(state):
+      [player.save_street_action_histories(state["street"]) for player in state["table"].seats.players]
       state["street"] += 1
-      state = self.__clear_action_histories(state)
       state, street_msgs = self.__start_street(state)
       return state, [update_msg] + street_msgs
     else:
@@ -186,13 +186,6 @@ class RoundManager:
   def __is_agreed(self, max_pay, player):
     return (player.paid_sum() == max_pay and len(player.action_histories) != 0)\
         or player.pay_info.status in [PayInfo.FOLDED, PayInfo.ALLIN]
-
-  @classmethod
-  def __clear_action_histories(self, state):
-    for player in state["table"].seats.players:
-      player.clear_action_histories()
-    return state
-
 
   @classmethod
   def __gen_initial_state(self, round_count, table):

--- a/tests/examples/players/console_player_test.py
+++ b/tests/examples/players/console_player_test.py
@@ -23,10 +23,12 @@ class ConsolePlayerTest(BaseUnitTest):
           'side': []
         },
         "round_count": 3,
-        "action_histories": [
-          {'action': 'SMALLBLIND', 'amount': 5, 'add_amount': 5},
-          {'action': 'BIGBLIND', 'amount': 10, 'add_amount': 5}
-        ]
+        "action_histories": {
+            "preflop": [
+                {'action': 'SMALLBLIND', 'amount': 5, 'add_amount': 5, "uuid": "ciglbcevkvoqzguqvnyhcb"},
+                {'action': 'BIGBLIND', 'amount': 10, 'add_amount': 5, "uuid": "zjttlanhlvpqzebrwmieho"}
+            ]
+        }
     }
 
   def test_declare_fold(self):

--- a/tests/pypokerengine/engine/card_test.py
+++ b/tests/pypokerengine/engine/card_test.py
@@ -24,3 +24,8 @@ class CardTest(BaseUnitTest):
     self.eq(Card.from_id(29), Card(Card.HEART, 3))
     self.eq(Card.from_id(40), Card(Card.SPADE, 1))
 
+  def test_from_str(self):
+    self.eq(Card(Card.CLUB, 14), Card.from_str("CA"))
+    self.eq(Card(Card.HEART, 10), Card.from_str("HT"))
+    self.eq(Card(Card.SPADE, 9), Card.from_str("S9"))
+    self.eq(Card(Card.DIAMOND, 12), Card.from_str("DQ"))

--- a/tests/pypokerengine/engine/data_encoder_test.py
+++ b/tests/pypokerengine/engine/data_encoder_test.py
@@ -105,7 +105,7 @@ class DataEncoderTest(BaseUnitTest):
         self.eq(["CA"], hsh["community_card"])
         self.eq(state["table"].dealer_btn, hsh["dealer_btn"])
         self.eq(state["next_player"], hsh["next_player"])
-        self.eq(DataEncoder.encode_action_histories(state["table"]), hsh["action_histories"])
+        self.eq(DataEncoder.encode_action_histories(state["table"])["action_histories"], hsh["action_histories"])
         self.eq(state["round_count"], hsh["round_count"])
 
 def setup_player():

--- a/tests/pypokerengine/engine/data_encoder_test.py
+++ b/tests/pypokerengine/engine/data_encoder_test.py
@@ -84,11 +84,17 @@ class DataEncoderTest(BaseUnitTest):
         p1, p2, p3 = table.seats.players
         hsh = DataEncoder.encode_action_histories(table)
         hsty = hsh["action_histories"]
-        self.eq(4, len(hsty))
-        self.eq(p3.action_histories[0], hsty[0])
-        self.eq(p1.action_histories[0], hsty[1])
-        self.eq(p2.action_histories[0], hsty[2])
-        self.eq(p3.action_histories[1], hsty[3])
+        self.eq(4, len(hsty["preflop"]))
+        fetch_info = lambda info: (info["action"], info["amount"])
+        self.eq(("RAISE", 10), fetch_info(hsty["preflop"][0]))
+        self.eq("FOLD", hsty["preflop"][1]["action"])
+        self.eq(("RAISE", 20), fetch_info(hsty["preflop"][2]))
+        self.eq(("CALL", 20), fetch_info(hsty["preflop"][3]))
+        self.eq(2, len(hsty["flop"]))
+        self.eq(("CALL", 5), fetch_info(hsty["flop"][0]))
+        self.eq(("RAISE", 5), fetch_info(hsty["flop"][1]))
+        self.assertFalse(hsty.has_key("turn"))
+        self.assertFalse(hsty.has_key("river"))
 
     def test_encode_winners(self):
         winners = [setup_player() for _ in range(2)]
@@ -136,7 +142,7 @@ def setup_seats():
 
 def setup_table():
     table = Table()
-    players = [Player("uuid", 100, "hoge") for _ in range(3)]
+    players = [Player("uuid%d"%i, 100, "hoge") for i in range(3)]
     table.seats.players = players
     table.add_community_card(Card.from_id(1))
     table.dealer_btn = 2
@@ -145,6 +151,9 @@ def setup_table():
     p1.add_action_history(Const.Action.FOLD)
     p2.add_action_history(Const.Action.RAISE, 20, 10)
     p3.add_action_history(Const.Action.CALL, 20)
+    [p.save_street_action_histories(Const.Street.PREFLOP) for p in [p1, p2, p3]]
+    p3.add_action_history(Const.Action.CALL, 5)
+    p2.add_action_history(Const.Action.RAISE, 5, 5)
     return table
 
 def setup_round_state():

--- a/tests/pypokerengine/engine/player_test.py
+++ b/tests/pypokerengine/engine/player_test.py
@@ -110,6 +110,24 @@ class PlayerTest(BaseUnitTest):
     self.eq(10, action["amount"])
     self.eq(5, action["add_amount"])
 
+  def test_save_street_action_histories(self):
+    self.assertIsNone(self.player.round_action_histories[Const.Street.PREFLOP])
+    self.player.add_action_history(Const.Action.BIG_BLIND)
+    self.player.save_street_action_histories(Const.Street.PREFLOP)
+    self.eq(1, len(self.player.round_action_histories[Const.Street.PREFLOP]))
+    self.eq("BIGBLIND", self.player.round_action_histories[Const.Street.PREFLOP][0]["action"])
+    self.eq(0, len(self.player.action_histories))
+
+  def test_clear_action_histories(self):
+    self.player.add_action_history(Const.Action.BIG_BLIND)
+    self.player.save_street_action_histories(Const.Street.PREFLOP)
+    self.player.add_action_history(Const.Action.CALL, 10)
+    self.assertIsNotNone(0, len(self.player.round_action_histories[Const.Street.PREFLOP]))
+    self.neq(0, len(self.player.action_histories))
+    self.player.clear_action_histories()
+    self.assertIsNone(self.player.round_action_histories[Const.Street.PREFLOP])
+    self.eq(0, len(self.player.action_histories))
+
   def test_serialization(self):
     player = self.__setup_player_for_serialization()
     serial = player.serialize()
@@ -119,16 +137,19 @@ class PlayerTest(BaseUnitTest):
     self.eq(player.stack, restored.stack)
     self.eq(player.hole_card, restored.hole_card)
     self.eq(player.action_histories, restored.action_histories)
+    self.eq(player.round_action_histories, restored.round_action_histories)
     self.eq(player.pay_info.amount, restored.pay_info.amount)
     self.eq(player.pay_info.status, restored.pay_info.status)
 
   def __setup_player_for_serialization(self):
     player = Player("uuid", 50, "hoge")
-    self.player.add_holecard([Card.from_id(cid) for cid in range(1,3)])
-    self.player.add_action_history(Const.Action.CALL, 10)
-    self.player.add_action_history(Const.Action.RAISE, 10, 5)
-    self.player.add_action_history(Const.Action.FOLD)
-    self.player.pay_info.update_by_pay(15)
-    self.player.pay_info.update_to_fold()
+    player.add_holecard([Card.from_id(cid) for cid in range(1,3)])
+    player.add_action_history(Const.Action.SMALL_BLIND)
+    player.save_street_action_histories(Const.Street.PREFLOP)
+    player.add_action_history(Const.Action.CALL, 10)
+    player.add_action_history(Const.Action.RAISE, 10, 5)
+    player.add_action_history(Const.Action.FOLD)
+    player.pay_info.update_by_pay(15)
+    player.pay_info.update_to_fold()
     return player
 

--- a/tests/pypokerengine/engine/round_manager_test.py
+++ b/tests/pypokerengine/engine/round_manager_test.py
@@ -90,6 +90,14 @@ class RoundManagerTest(BaseUnitTest):
     self.eq(0, state["next_player"])
     self.eq([Card.from_id(cid) for cid in range(7,10)], state["table"].get_community_card())
 
+    fetch_player = lambda uuid: [p for p in state["table"].seats.players if p.uuid==uuid][0]
+    self.true(all(map(lambda p: len(p.action_histories)==0, state["table"].seats.players)))
+    self.eq(2, len(fetch_player("uuid0").round_action_histories[Const.Street.PREFLOP]))
+    self.eq(1, len(fetch_player("uuid1").round_action_histories[Const.Street.PREFLOP]))
+    self.eq(1, len(fetch_player("uuid2").round_action_histories[Const.Street.PREFLOP]))
+    self.assertIsNone(fetch_player("uuid0").round_action_histories[Const.Street.TURN])
+
+
   def test_state_after_forward_to_turn(self):
     state, _ = self.__start_round()
     state, _ = RoundManager.apply_action(state, "fold", 0)
@@ -100,6 +108,16 @@ class RoundManagerTest(BaseUnitTest):
     self.eq(Const.Street.TURN, state["street"])
     self.eq([Card.from_id(cid) for cid in range(7,11)], state["table"].get_community_card())
     self.eq(3, len(msgs))
+
+    fetch_player = lambda uuid: [p for p in state["table"].seats.players if p.uuid==uuid][0]
+    self.true(all(map(lambda p: len(p.action_histories)==0, state["table"].seats.players)))
+    self.eq(2, len(fetch_player("uuid0").round_action_histories[Const.Street.PREFLOP]))
+    self.eq(1, len(fetch_player("uuid1").round_action_histories[Const.Street.PREFLOP]))
+    self.eq(1, len(fetch_player("uuid2").round_action_histories[Const.Street.PREFLOP]))
+    self.eq(1, len(fetch_player("uuid0").round_action_histories[Const.Street.FLOP]))
+    self.eq(1, len(fetch_player("uuid1").round_action_histories[Const.Street.FLOP]))
+    self.eq(0, len(fetch_player("uuid2").round_action_histories[Const.Street.FLOP]))
+    self.assertIsNone(fetch_player("uuid0").round_action_histories[Const.Street.TURN])
 
   def test_state_after_forward_to_river(self):
     state, _ = self.__start_round()
@@ -113,6 +131,19 @@ class RoundManagerTest(BaseUnitTest):
     self.eq(Const.Street.RIVER, state["street"])
     self.eq([Card.from_id(cid) for cid in range(7,12)], state["table"].get_community_card())
     self.eq(3, len(msgs))
+
+    fetch_player = lambda uuid: [p for p in state["table"].seats.players if p.uuid==uuid][0]
+    self.true(all(map(lambda p: len(p.action_histories)==0, state["table"].seats.players)))
+    self.eq(2, len(fetch_player("uuid0").round_action_histories[Const.Street.PREFLOP]))
+    self.eq(1, len(fetch_player("uuid1").round_action_histories[Const.Street.PREFLOP]))
+    self.eq(1, len(fetch_player("uuid2").round_action_histories[Const.Street.PREFLOP]))
+    self.eq(1, len(fetch_player("uuid0").round_action_histories[Const.Street.FLOP]))
+    self.eq(1, len(fetch_player("uuid1").round_action_histories[Const.Street.FLOP]))
+    self.eq(0, len(fetch_player("uuid2").round_action_histories[Const.Street.FLOP]))
+    self.eq(1, len(fetch_player("uuid0").round_action_histories[Const.Street.TURN]))
+    self.eq(1, len(fetch_player("uuid1").round_action_histories[Const.Street.TURN]))
+    self.eq(0, len(fetch_player("uuid2").round_action_histories[Const.Street.TURN]))
+    self.assertIsNone(fetch_player("uuid0").round_action_histories[Const.Street.RIVER])
 
   def test_state_after_showdown(self):
     mock_return = [1,0]*3
@@ -132,6 +163,9 @@ class RoundManagerTest(BaseUnitTest):
       self.eq(110, state["table"].seats.players[0].stack)
       self.eq( 90, state["table"].seats.players[1].stack)
       self.eq(100, state["table"].seats.players[2].stack)
+
+      self.true(all(map(lambda p: len(p.action_histories)==0, state["table"].seats.players)))
+      self.true(all(map(lambda p: p.round_action_histories==[None]*4, state["table"].seats.players)))
 
   def test_message_after_showdown(self):
     mock_return = [1,0]*3


### PR DESCRIPTION
Updated `action_histories` to include past street information like this.

```
{
'preflop':
    [
        {'action': 'SMALLBLIND', 'amount': 5, 'add_amount': 5, 'uuid': 'yziwyjmkmaemiyfovgiwzj'},
         {'action': 'BIGBLIND', 'amount': 10, 'add_amount': 5, 'uuid': 'vvqxgkcnolwobmlfqtkklr'},
         {'action': 'RAISE', 'amount': 15, 'add_amount': 5, 'paid': 10, 'uuid': 'yziwyjmkmaemiyfovgiwzj'},
         {'action': 'CALL', 'amount': 15, 'uuid': 'vvqxgkcnolwobmlfqtkklr', 'paid': 5}
    ],
 'flop':
     [
          {'action': 'CALL', 'amount': 0, 'uuid': 'yziwyjmkmaemiyfovgiwzj', 'paid': 0},
          {'action': 'CALL', 'amount': 0, 'uuid': 'vvqxgkcnolwobmlfqtkklr', 'paid': 0}
    ]
}
```

Because without past information, Emulator cannot restore 
`game_state` from [`round_state`, `action_histories`]