### PR TITLE
Folded player is asked action when his position is dealer_btn

### DIFF
--- a/pypokerengine/engine/round_manager.py
+++ b/pypokerengine/engine/round_manager.py
@@ -59,7 +59,8 @@ class RoundManager:
 
   @classmethod
   def __start_street(self, state):
-    state["next_player"] = state["table"].dealer_btn
+    next_player_pos = state["table"].next_active_player_pos(state["table"].dealer_btn-1)
+    state["next_player"] = next_player_pos
     street = state["street"]
     if street == Const.Street.PREFLOP:
       return self.__preflop(state)

--- a/pypokerengine/engine/table.py
+++ b/pypokerengine/engine/table.py
@@ -32,6 +32,7 @@ class Table:
   def next_active_player_pos(self, player_pos):
     while True:
       player_pos = (player_pos + 1) % self.seats.size()
+      assert(player_pos >= 0)
       if self.seats.players[player_pos].is_active(): break
     return player_pos
 

--- a/tests/pypokerengine/engine/round_manager_test.py
+++ b/tests/pypokerengine/engine/round_manager_test.py
@@ -213,6 +213,15 @@ class RoundManagerTest(BaseUnitTest):
     self.eq(Const.Street.FINISHED, state["street"])
     self.false("street_start_message" in [msg["message"]["message_type"] for _, msg in msgs])
 
+  def test_ask_player_target_when_dealer_btn_player_is_folded(self):
+    state, _ = self.__start_round()
+    state, _ = RoundManager.apply_action(state, "call", 10)
+    state, _ = RoundManager.apply_action(state, "call", 10)
+    state, _ = RoundManager.apply_action(state, "fold", 10)
+    state, _ = RoundManager.apply_action(state, "call", 0)
+    state, msgs = RoundManager.apply_action(state, "call", 0)
+    self.eq("uuid1", msgs[-1][0])
+
   def __start_round(self):
     table = self.__setup_table()
     round_count = 1


### PR DESCRIPTION
**How to reproduce bug**
This bug occurs only when more than 3 players game
1. player1 is sitting on dealer_btn position
2. player1 is folded on streetA (ex. flop)
3. forward to streetB (ex. turn)
4. player1 is asked the action
```
==============================================
 Players
 0 : p1 (jdxmhwbudsexdshzxiojzr) => state : folded, stack : 90 <= SB
 1 : p2 (eflsafydhdsaqjeymalozl) => state : participating, stack : 90 <= BB, CURRENT
 2 : p3 (qnfewdmgfzzrtldqfekzeg) => state : participating, stack : 90
-- action histories --
  preflop
    {'action': 'SMALLBLIND', 'player': 'p1 (uuid=jdxmhwbudsexdshzxiojzr)', 'amount': 5, 'add_amount': 5}
    {'action': 'BIGBLIND', 'player': 'p2 (uuid=eflsafydhdsaqjeymalozl)', 'amount': 10, 'add_amount': 5}
    {'action': 'CALL', 'player': 'p3 (uuid=qnfewdmgfzzrtldqfekzeg)', 'amount': 10, 'paid': 10}
    {'action': 'CALL', 'player': 'p1 (uuid=jdxmhwbudsexdshzxiojzr)', 'amount': 10, 'paid': 5}
  flop
    {'action': 'FOLD', 'player': 'p1 (uuid=jdxmhwbudsexdshzxiojzr)'}
    {'action': 'CALL', 'player': 'p2 (uuid=eflsafydhdsaqjeymalozl)', 'amount': 0, 'paid': 0}
    {'action': 'CALL', 'player': 'p3 (uuid=qnfewdmgfzzrtldqfekzeg)', 'amount': 0, 'paid': 0}
  turn
    {'action': 'CALL', 'player': 'p1 (uuid=jdxmhwbudsexdshzxiojzr)', 'amount': 0, 'paid': 0}
    {'action': 'CALL', 'player': 'p2 (uuid=eflsafydhdsaqjeymalozl)', 'amount': 0, 'paid': 0}
    {'action': 'CALL', 'player': 'p3 (uuid=qnfewdmgfzzrtldqfekzeg)', 'amount': 0, 'paid': 0}
  river
    {'action': 'CALL', 'player': 'p1 (uuid=jdxmhwbudsexdshzxiojzr)', 'amount': 0, 'paid': 0}
==============================================
```