### PR TITLE
Fix bug that allin player is asked action

### DIFF
--- a/examples/players/console_player.py
+++ b/examples/players/console_player.py
@@ -193,7 +193,8 @@ class ConsoleWriter:
       print "  hole => [%s, %s]" % (hole["high"], hole["low"])
 
   def __is_next_player(self, player, round_state):
-    return round_state and player == round_state["seats"][round_state["next_player"]]
+    return round_state and not isinstance(round_state["next_player"], str)\
+            and player == round_state["seats"][round_state["next_player"]]
 
   def __gen_batch(self, is_sb=False, is_bb=False, is_next=False):
     batches = []

--- a/pypokerengine/engine/dealer.py
+++ b/pypokerengine/engine/dealer.py
@@ -88,7 +88,7 @@ class Dealer:
   def __prepare_for_next_round(self, table):
     table.shift_dealer_btn()
     small_blind_pos = table.dealer_btn
-    big_blind_pos = table.next_active_player_pos(small_blind_pos)
+    big_blind_pos = table.next_ask_waiting_player_pos(small_blind_pos)
     self.__exclude_cannot_pay_blind_player(small_blind_pos, big_blind_pos, table.seats.players)
     self.__exclude_no_money_player(table.seats.players)
     return table

--- a/pypokerengine/engine/player.py
+++ b/pypokerengine/engine/player.py
@@ -37,6 +37,9 @@ class Player:
   def is_active(self):
     return self.pay_info.status != PayInfo.FOLDED
 
+  def is_waiting_ask(self):
+    return self.pay_info.status == PayInfo.PAY_TILL_END
+
   def add_action_history(self, kind, chip_amount=None, add_amount=None):
     history = None
     if kind == Const.Action.FOLD:

--- a/pypokerengine/engine/round_manager.py
+++ b/pypokerengine/engine/round_manager.py
@@ -31,7 +31,7 @@ class RoundManager:
       state, street_msgs = self.__start_street(state)
       return state, [update_msg] + street_msgs
     else:
-      state["next_player"] = state["table"].next_active_player_pos(state["next_player"])
+      state["next_player"] = state["table"].next_ask_waiting_player_pos(state["next_player"])
       next_player_pos = state["next_player"]
       next_player = state["table"].seats.players[next_player_pos]
       ask_message = (next_player.uuid, MessageBuilder.build_ask_message(next_player_pos, state))
@@ -41,7 +41,7 @@ class RoundManager:
   @classmethod
   def __correct_blind(self, sb_amount, table):
     small_blind_pos = table.dealer_btn
-    big_blind_pos = table.next_active_player_pos(small_blind_pos)
+    big_blind_pos = table.next_ask_waiting_player_pos(small_blind_pos)
     self.__blind_transaction(table.seats.players[small_blind_pos], True, sb_amount)
     self.__blind_transaction(table.seats.players[big_blind_pos], False, sb_amount*2)
 
@@ -59,7 +59,7 @@ class RoundManager:
 
   @classmethod
   def __start_street(self, state):
-    next_player_pos = state["table"].next_active_player_pos(state["table"].dealer_btn-1)
+    next_player_pos = state["table"].next_ask_waiting_player_pos(state["table"].dealer_btn-1)
     state["next_player"] = next_player_pos
     street = state["street"]
     if street == Const.Street.PREFLOP:
@@ -78,7 +78,7 @@ class RoundManager:
   @classmethod
   def __preflop(self, state):
     for i in range(2):
-      state["next_player"] = state["table"].next_active_player_pos(state["next_player"])
+      state["next_player"] = state["table"].next_ask_waiting_player_pos(state["next_player"])
     return self.__forward_street(state)
 
   @classmethod

--- a/pypokerengine/engine/seats.py
+++ b/pypokerengine/engine/seats.py
@@ -16,8 +16,7 @@ class Seats:
     return len([p for p in self.players if p.is_active()])
 
   def count_ask_wait_players(self):
-    is_paying = lambda player: player.pay_info.status == PayInfo.PAY_TILL_END
-    return len([p for p in self.players if is_paying(p)])
+    return len([p for p in self.players if p.is_waiting_ask()])
 
   def serialize(self):
     return [player.serialize() for player in self.players]

--- a/pypokerengine/engine/table.py
+++ b/pypokerengine/engine/table.py
@@ -29,12 +29,11 @@ class Table:
   def shift_dealer_btn(self):
     self.dealer_btn = self.next_active_player_pos(self.dealer_btn)
 
-  def next_active_player_pos(self, player_pos):
-    while True:
-      player_pos = (player_pos + 1) % self.seats.size()
-      assert(player_pos >= 0)
-      if self.seats.players[player_pos].is_active(): break
-    return player_pos
+  def next_active_player_pos(self, start_pos):
+    return self.__find_entitled_player_pos(start_pos, lambda player: player.is_active())
+
+  def next_ask_waiting_player_pos(self, start_pos):
+    return self.__find_entitled_player_pos(start_pos, lambda player: player.is_waiting_ask())
 
   def serialize(self):
     community_card = [card.to_id() for card in self.__community_card]
@@ -53,5 +52,14 @@ class Table:
     table.__community_card = community_card
     return table
 
+  def __find_entitled_player_pos(self, start_pos, check_method):
+    players = self.seats.players
+    search_targets = players + players
+    search_targets = search_targets[start_pos+1:start_pos+len(players)+1]
+    assert(len(search_targets) == len(players))
+    match_player = next((player for player in search_targets if check_method(player)), -1)
+    return self._player_not_found if match_player == -1 else players.index(match_player)
+
+  _player_not_found = "not_found"
 
   __exceed_card_size_msg = "Community card is already full"

--- a/tests/pypokerengine/engine/player_test.py
+++ b/tests/pypokerengine/engine/player_test.py
@@ -61,6 +61,18 @@ class PlayerTest(BaseUnitTest):
     self.player.collect_bet(100)
     self.true(self.player.is_active())
 
+  def test_is_waiting_ask(self):
+    self.player.pay_info.update_by_pay(10)
+    self.true(self.player.is_waiting_ask())
+
+  def test_if_allin_player_is_not_waiting_ask(self):
+    self.player.pay_info.update_to_allin()
+    self.false(self.player.is_waiting_ask())
+
+  def test_if_folded_player_is_not_waiting_ask(self):
+    self.player.pay_info.update_to_fold()
+    self.false(self.player.is_waiting_ask())
+
   def test_add_fold_action_history(self):
     self.player.add_action_history(Const.Action.FOLD)
     self.eq("FOLD", self.player.action_histories[-1]["action"])

--- a/tests/pypokerengine/engine/round_manager_test.py
+++ b/tests/pypokerengine/engine/round_manager_test.py
@@ -222,6 +222,50 @@ class RoundManagerTest(BaseUnitTest):
     state, msgs = RoundManager.apply_action(state, "call", 0)
     self.eq("uuid1", msgs[-1][0])
 
+  def test_skip_asking_to_allin_player(self):
+    state, _ = self.__start_round()
+    # Round 1
+    state, _ = RoundManager.apply_action(state, "call", 10)
+    state, _ = RoundManager.apply_action(state, "fold", 0)
+    state, _ = RoundManager.apply_action(state, "raise", 50)
+    state, _ = RoundManager.apply_action(state, "call", 50)
+    state, _ = RoundManager.apply_action(state, "fold", 0)
+    self.eq([95, 40, 165], [p.stack for p in state["table"].seats.players])
+    # Round 2
+    state["table"].shift_dealer_btn()
+    state, _ = RoundManager.start_new_round(2, 5, state["table"])
+    state, _ = RoundManager.apply_action(state, "raise", 40)
+    state, _ = RoundManager.apply_action(state, "call", 40)
+    state, _ = RoundManager.apply_action(state, "raise", 70)
+    state, msgs = RoundManager.apply_action(state, "call", 70)
+    self.eq([25, 0, 95], [p.stack for p in state["table"].seats.players])
+    self.eq(1, state["street"])
+    self.eq("uuid2", msgs[-1][0])
+
+  def test_when_only_one_player_is_waiting_ask(self):
+    state, _ = self.__start_round()
+    # Round 1
+    state, _ = RoundManager.apply_action(state, "call", 10)
+    state, _ = RoundManager.apply_action(state, "fold", 0)
+    state, _ = RoundManager.apply_action(state, "raise", 50)
+    state, _ = RoundManager.apply_action(state, "call", 50)
+    state, _ = RoundManager.apply_action(state, "fold", 0)
+    self.eq([95, 40, 165], [p.stack for p in state["table"].seats.players])
+    # Round 2
+    state["table"].shift_dealer_btn()
+    state, _ = RoundManager.start_new_round(2, 5, state["table"])
+    state, _ = RoundManager.apply_action(state, "raise", 40)
+    state, _ = RoundManager.apply_action(state, "call", 40)
+    state, _ = RoundManager.apply_action(state, "raise", 70)
+    state, _ = RoundManager.apply_action(state, "call", 70)
+    state, _ = RoundManager.apply_action(state, "call", 0)
+    state, _ = RoundManager.apply_action(state, "raise", 10)
+    state, _ = RoundManager.apply_action(state, "call", 10)
+    state, _ = RoundManager.apply_action(state, "raise", 85)
+    state, _ = RoundManager.apply_action(state, "call", 85)
+
+
+
   def __start_round(self):
     table = self.__setup_table()
     round_count = 1

--- a/tests/pypokerengine/engine/table_test.py
+++ b/tests/pypokerengine/engine/table_test.py
@@ -42,6 +42,19 @@ class TableTest(BaseUnitTest):
     table.shift_dealer_btn()
     self.eq(0, table.dealer_btn)
 
+  def test_next_ask_waiting_player_pos(self):
+    table = self.__setup_players_with_table()
+    self.eq(0, table.next_ask_waiting_player_pos(0))
+    self.eq(0, table.next_ask_waiting_player_pos(1))
+    self.eq(0, table.next_ask_waiting_player_pos(2))
+
+  def test_next_ask_waitint_player_pos_when_no_one_waiting(self):
+    table = self.__setup_players_with_table()
+    table.seats.players[0].pay_info.update_to_allin()
+    self.eq(table._player_not_found, table.next_ask_waiting_player_pos(0))
+    self.eq(table._player_not_found, table.next_ask_waiting_player_pos(1))
+    self.eq(table._player_not_found, table.next_ask_waiting_player_pos(2))
+
   def test_serialization(self):
     table = self.__setup_players_with_table()
     for card in table.deck.draw_cards(3):


### PR DESCRIPTION
**The reason**
Now RoundManager toggles next player by just checking if next player is not folded.
But he should also check that next player is not all-in. (and if so, he should skip the player)
```
# The code where RoundManager toggles the next_player postion
state["next_player"] = state["table"].next_active_player_pos(state["next_player"])
```

So added new checking method on player like below and used it in RoundManager.
```
player.is_waiting_ask()
```