### PR TITLE
Bugfix twopair highcard judge

### DIFF
--- a/pypokerengine/engine/hand_evaluator.py
+++ b/pypokerengine/engine/hand_evaluator.py
@@ -104,7 +104,7 @@ class HandEvaluator:
   @classmethod
   def __eval_twopair(self, cards):
     ranks = self.__search_twopair(cards)
-    return ranks[1] << 4 | ranks[0]
+    return ranks[0] << 4 | ranks[1]
 
   @classmethod
   def __search_twopair(self, cards):
@@ -114,7 +114,7 @@ class HandEvaluator:
       mask = 1 << card.rank
       if memo & mask != 0: ranks.append(card.rank)
       memo |= mask
-    return sorted(ranks)[:2]
+    return sorted(ranks)[::-1][:2]
 
   @classmethod
   def __is_threecard(self, cards):

--- a/tests/pypokerengine/engine/hand_evaluator_test.py
+++ b/tests/pypokerengine/engine/hand_evaluator_test.py
@@ -80,8 +80,25 @@ class HandEvaluatorTest(BaseUnitTest):
     self.eq(HandEvaluator.TWOPAIR, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
     self.eq(9, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
     self.eq(3, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
-    self.eq(9, HandEvaluator._HandEvaluator__mask_hole_high_rank(bit))
-    self.eq(3, HandEvaluator._HandEvaluator__mask_hole_low_rank(bit))
+
+  def test_twopair2(self):
+    community = [
+        Card(Card.DIAMOND, 4),
+        Card(Card.SPADE, 8),
+        Card(Card.HEART, 4),
+        Card(Card.DIAMOND, 7),
+        Card(Card.CLUB, 8)
+        ]
+    hole = [
+        Card(Card.CLUB, 7),
+        Card(Card.SPADE, 5)
+        ]
+
+    bit = HandEvaluator.eval_hand(hole, community)
+    self.eq(HandEvaluator.TWOPAIR, HandEvaluator._HandEvaluator__mask_hand_strength(bit))
+    self.eq(8, HandEvaluator._HandEvaluator__mask_hand_high_rank(bit))
+    self.eq(7, HandEvaluator._HandEvaluator__mask_hand_low_rank(bit))
+
 
   def test_threecard(self):
     community = [


### PR DESCRIPTION
I found wrong hand judge on twopair.
if **hole = [7, 5],community=['D4', 'S8', 'H4', 'D7', 'C8']**
then hand should be evaluated as **twopair of 8 and 7**
but judged as **twopair of 7 and 4**

```
 -- Round Result (UUID = eslcanounwpanqnpfozynx) --
==============================================
-- winners --
 p1 (nmtagflsjcueqoinsdlmal) => state : participating, stack : 126
-- hand info --
player [nmtagflsjcueqoinsdlmal]
  hand => TWOPAIR (high=8, low=4)
  hole => [13, 6]
player [xsijmwmfmfxosvmsexjuri]
  hand => TWOPAIR (high=7, low=4)
  hole => [7, 5]
-- round state --
 Street : showdown
 Community Card : ['D4', 'S8', 'H4', 'D7', 'C8']
 Pot : main = 120, side = []
 Dealer Btn : p3 
 Players
 0 : p1 (nmtagflsjcueqoinsdlmal) => state : participating, stack : 126 <= BB
 1 : p2 (eslcanounwpanqnpfozynx) => state : folded, stack : 0
 2 : p3 (xsijmwmfmfxosvmsexjuri) => state : participating, stack : 174 <= SB
==============================================
```