### PR TITLE
Support blind structure

### DIFF
--- a/pypokerengine/api/game.py
+++ b/pypokerengine/api/game.py
@@ -8,6 +8,7 @@ def start_poker(config, verbose=2):
     config.validation()
     dealer = Dealer(config.sb_amount, config.initial_stack)
     dealer.set_verbose(verbose)
+    dealer.set_blind_structure(config.blind_structure)
     for info in config.players_info:
         dealer.register_player(info["name"], info["algorithm"])
     return dealer.start_game(config.max_round)
@@ -16,6 +17,7 @@ class Config(object):
 
     def __init__(self, max_round, initial_stack, sb_amount):
         self.players_info = []
+        self.blind_structure = {}
         self.max_round = max_round
         self.initial_stack = initial_stack
         self.sb_amount = sb_amount
@@ -27,6 +29,9 @@ class Config(object):
 
         info = { "name" : name, "algorithm" : algorithm }
         self.players_info.append(info)
+
+    def set_blind_structure(self, blind_structure):
+        self.blind_structure = blind_structure
 
     def validation(self):
         player_num = len(self.players_info)

--- a/pypokerengine/api/game.py
+++ b/pypokerengine/api/game.py
@@ -1,12 +1,12 @@
 from pypokerengine.engine.dealer import Dealer
 from pypokerengine.players import BasePokerPlayer
 
-def setup_config(max_round, initial_stack, small_blind_amount):
-    return Config(max_round, initial_stack, small_blind_amount)
+def setup_config(max_round, initial_stack, small_blind_amount, ante=0):
+    return Config(max_round, initial_stack, small_blind_amount, ante)
 
 def start_poker(config, verbose=2):
     config.validation()
-    dealer = Dealer(config.sb_amount, config.initial_stack)
+    dealer = Dealer(config.sb_amount, config.initial_stack, config.ante)
     dealer.set_verbose(verbose)
     dealer.set_blind_structure(config.blind_structure)
     for info in config.players_info:
@@ -15,12 +15,13 @@ def start_poker(config, verbose=2):
 
 class Config(object):
 
-    def __init__(self, max_round, initial_stack, sb_amount):
+    def __init__(self, max_round, initial_stack, sb_amount, ante):
         self.players_info = []
         self.blind_structure = {}
         self.max_round = max_round
         self.initial_stack = initial_stack
         self.sb_amount = sb_amount
+        self.ante = ante
 
     def register_player(self, name, algorithm):
         if not isinstance(algorithm, BasePokerPlayer):

--- a/pypokerengine/engine/dealer.py
+++ b/pypokerengine/engine/dealer.py
@@ -37,7 +37,7 @@ class Dealer:
     return self.__generate_game_result(max_round, table.seats)
 
   def play_round(self, round_count, blind_amount, table):
-    state, msgs = RoundManager.start_new_round(round_count, blind_amount, table)
+    state, msgs = RoundManager.start_new_round(round_count, blind_amount, 0, table) #TODO ante
     while True:
       self.__message_check(msgs, state["street"])
       if state["street"] != Const.Street.FINISHED:  # continue the round

--- a/pypokerengine/engine/dealer.py
+++ b/pypokerengine/engine/dealer.py
@@ -65,6 +65,9 @@ class Dealer:
   def __update_forced_bet_amount(self, ante, sb_amount, round_count, blind_structure):
     if blind_structure.has_key(round_count):
       update_info = blind_structure[round_count]
+      msg = self.message_summarizer.summairze_blind_level_update(\
+              round_count, ante, update_info["ante"], sb_amount, update_info["small_blind"])
+      self.message_summarizer.print_message(msg)
       ante, sb_amount = update_info["ante"], update_info["small_blind"]
     return ante, sb_amount
 
@@ -198,14 +201,16 @@ class MessageSummarizer(object):
     def __init__(self, verbose):
         self.verbose = verbose
 
+    def print_message(self, message):
+        print message
+
     def summarize_messages(self, raw_messages):
         if self.verbose == 0: return
 
         summaries = [self.summarize(raw_message[1]) for raw_message in raw_messages]
         summaries = [summary for summary in summaries if summary is not None]
         summaries = list(OrderedDict.fromkeys(summaries))
-        for summary in summaries:
-            print summary
+        for summary in summaries: self.print_message(summary)
 
     def summarize(self, message):
         if self.verbose == 0: return None
@@ -256,4 +261,8 @@ class MessageSummarizer(object):
         base = 'Game finished. (stack = %s)'
         stack = { player["name"]:player["stack"] for player in message["game_information"]["seats"] }
         return base % stack
+
+    def summairze_blind_level_update(self, round_count, old_ante, new_ante, old_sb_amount, new_sb_amount):
+        base = 'Blind level update at round-%d : Ante %s -> %s, SmallBlind %s -> %s'
+        return base % (round_count, old_ante, new_ante, old_sb_amount, new_sb_amount)
 

--- a/pypokerengine/engine/player.py
+++ b/pypokerengine/engine/player.py
@@ -52,6 +52,8 @@ class Player:
       history = self.__blind_history(True, sb_amount)
     elif kind == Const.Action.BIG_BLIND:
       history = self.__blind_history(False, sb_amount)
+    elif kind == Const.Action.ANTE:
+      history = self.__ante_history(chip_amount)
     else:
       raise "UnKnown action history is added (kind = %s)" % kind
     history = self.__add_uuid_on_history(history)
@@ -127,6 +129,13 @@ class Player:
         "action" : action,
         "amount" : amount,
         "add_amount" : add_amount
+        }
+
+  def __ante_history(self, pay_amount):
+    assert(pay_amount > 0)
+    return {
+        "action" : "ANTE",
+        "amount" : pay_amount
         }
 
   def __add_uuid_on_history(self, history):

--- a/pypokerengine/engine/poker_constants.py
+++ b/pypokerengine/engine/poker_constants.py
@@ -6,6 +6,7 @@ class PokerConstants:
     RAISE = 2
     SMALL_BLIND = 3
     BIG_BLIND = 4
+    ANTE = 5
 
   class Street:
     PREFLOP = 0

--- a/pypokerengine/engine/round_manager.py
+++ b/pypokerengine/engine/round_manager.py
@@ -41,7 +41,8 @@ class RoundManager:
   @classmethod
   def __correct_ante(self, ante_amount, players):
     if ante_amount == 0: return
-    for player in players:
+    active_players = [player for player in players if player.is_active()]
+    for player in active_players:
       player.collect_bet(ante_amount)
       player.pay_info.update_by_pay(ante_amount)
       player.add_action_history(Const.Action.ANTE, ante_amount)

--- a/tests/examples/players/round_simulator_test.py
+++ b/tests/examples/players/round_simulator_test.py
@@ -16,7 +16,7 @@ class RoundSimulatorTest(BaseUnitTest):
 
   def test_simulation(self):
     round_count, small_blind = 1, 5
-    initial_state, _ = RoundManager.start_new_round(round_count, small_blind, self.table)
+    initial_state, _ = RoundManager.start_new_round(round_count, small_blind, 0, self.table)
     for i in range(2):
       action = self.simualtor.gen_action_info(RoundSimualtor.CALL, 10)
       round_result = self.simualtor.start_simulation(initial_state, action)

--- a/tests/pypokerengine/api/game_test.py
+++ b/tests/pypokerengine/api/game_test.py
@@ -7,7 +7,7 @@ from examples.players.fold_man import PokerPlayer as FoldMan
 class GameTest(BaseUnitTest):
 
     def test_start_poker(self):
-        config = G.Config(1, 100, 10)
+        config = G.setup_config(1, 100, 10)
         config.register_player("p1", FoldMan())
         config.register_player("p2", FoldMan())
         result = G.start_poker(config)
@@ -17,8 +17,19 @@ class GameTest(BaseUnitTest):
         self.eq("p2", p2["name"])
         self.eq(110, p2["stack"])
 
+    def test_start_poker_with_ante(self):
+        config = G.setup_config(1, 100, 10, 15)
+        config.register_player("p1", FoldMan())
+        config.register_player("p2", FoldMan())
+        result = G.start_poker(config)
+        p1, p2 = [result["message"]["game_information"]["seats"][i] for i in range(2)]
+        self.eq("p1", p1["name"])
+        self.eq(75, p1["stack"])
+        self.eq("p2", p2["name"])
+        self.eq(125, p2["stack"])
+
     def test_set_blind_structure(self):
-        config = G.Config(1, 100, 10)
+        config = G.setup_config(1, 100, 10)
         config.register_player("p1", FoldMan())
         config.register_player("p2", FoldMan())
         config.set_blind_structure({ 1: { "ante":5, "small_blind":10 } })
@@ -28,13 +39,13 @@ class GameTest(BaseUnitTest):
         self.eq(115, p2["stack"])
 
     def test_start_poker_validation_when_no_player(self):
-        config = G.Config(1, 100, 10)
+        config = G.setup_config(1, 100, 10)
         with self.assertRaises(Exception) as e:
             result = G.start_poker(config)
         self.assertIn("no player", e.exception.message)
 
     def test_start_poker_validation_when_one_player(self):
-        config = G.Config(1, 100, 10)
+        config = G.setup_config(1, 100, 10)
         config.register_player("p1", FoldMan())
         with self.assertRaises(Exception) as e:
             result = G.start_poker(config)
@@ -42,6 +53,6 @@ class GameTest(BaseUnitTest):
 
     @raises(TypeError)
     def test_register_player_when_invalid(self):
-        config = G.Config(1, 100, 10)
+        config = G.setup_config(1, 100, 10)
         config.register_player("p1", "dummy")
 

--- a/tests/pypokerengine/api/game_test.py
+++ b/tests/pypokerengine/api/game_test.py
@@ -17,6 +17,16 @@ class GameTest(BaseUnitTest):
         self.eq("p2", p2["name"])
         self.eq(110, p2["stack"])
 
+    def test_set_blind_structure(self):
+        config = G.Config(1, 100, 10)
+        config.register_player("p1", FoldMan())
+        config.register_player("p2", FoldMan())
+        config.set_blind_structure({ 1: { "ante":5, "small_blind":10 } })
+        result = G.start_poker(config)
+        p1, p2 = [result["message"]["game_information"]["seats"][i] for i in range(2)]
+        self.eq(85, p1["stack"])
+        self.eq(115, p2["stack"])
+
     def test_start_poker_validation_when_no_player(self):
         config = G.Config(1, 100, 10)
         with self.assertRaises(Exception) as e:

--- a/tests/pypokerengine/engine/dealer_message_summarizer_test.py
+++ b/tests/pypokerengine/engine/dealer_message_summarizer_test.py
@@ -54,6 +54,11 @@ class MessageSummarizerTest(BaseUnitTest):
         #expected = 'Game finished. (stack = { p1 : 100, p2 : 100 })'
         self._check_words(["finished", "p1", "100", "p2", "100"], summary)
 
+    def test_summarize_blind_level_update(self):
+        summary = self.summarizer.summairze_blind_level_update(1, 2, 3, 4, 5)
+        #expected = 'Blind level update at round-1 : Ante 2 -> 3, SmallBlind 4 -> 5'
+        self._check_words(["1", "2", "3", "4", "5"], summary)
+
     def _check_words(self, targets, source):
         for target in targets:
             self.assertIn(target, source)

--- a/tests/pypokerengine/engine/player_test.py
+++ b/tests/pypokerengine/engine/player_test.py
@@ -122,6 +122,16 @@ class PlayerTest(BaseUnitTest):
     self.eq(10, action["amount"])
     self.eq(5, action["add_amount"])
 
+  def test_add_ante_history(self):
+    self.player.add_action_history(Const.Action.ANTE, 10)
+    action = self.player.action_histories[-1]
+    self.eq("ANTE", action["action"])
+    self.eq(10, action["amount"])
+
+  @raises(AssertionError)
+  def test_add_empty_ante_history(self):
+    self.player.add_action_history(Const.Action.ANTE, 0)
+
   def test_save_street_action_histories(self):
     self.assertIsNone(self.player.round_action_histories[Const.Street.PREFLOP])
     self.player.add_action_history(Const.Action.BIG_BLIND, sb_amount=5)

--- a/tests/pypokerengine/engine/round_manager_test.py
+++ b/tests/pypokerengine/engine/round_manager_test.py
@@ -42,6 +42,16 @@ class RoundManagerTest(BaseUnitTest):
     self.eq(ante, players[2].pay_info.amount)
     self.eq(sb_amount+sb_amount*2+ante*3, GameEvaluator.create_pot(players)[0]["amount"])
 
+  def test_collect_ante_skip_loser(self):
+    ante = 10
+    sb_amount = 5
+    table = self.__setup_table()
+    table.seats.players[2].stack = 0
+    table.seats.players[2].pay_info.status = PayInfo.FOLDED
+    state, _ = RoundManager.start_new_round(1, sb_amount, ante, table)
+    players = state["table"].seats.players
+    self.eq(sb_amount+sb_amount*2+ante*2, GameEvaluator.create_pot(players)[0]["amount"])
+
   def test_deal_holecard(self):
     state, _ = self.__start_round()
     players = state["table"].seats.players


### PR DESCRIPTION
Implemented
- support Ante
- support blind structure to update Ante and Blind amount at some round

If you want to set blind strucure which **update Ante and Blind at round 5**,
you can do it like below code
```
from pypokerengine.api.game import setup_config
config = setup_config(max_round=10, initial_stack=100, small_blind_amount=10, ante=5);
config.set_blind_structure({5:{"ante":15, "small_blind":20}});
```