### PR TITLE
Add utility method on emulator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'PyPokerEngine',
-    version = '0.1.0',
+    version = '0.1.1',
     author = 'ishikota',
     author_email = 'ishikota086@gmail.com',
     description = 'Poker engine for poker AI development in Python ',


### PR DESCRIPTION
Update `Emulator` class to support manipulating game state from initial state like below
and release as 0.1.1
```
from pypokerengine.api.emulator import Emulator
from examples.players.fold_man import FoldMan
e = Emulator()
e.set_game_rule(3, 10, 5, 0,)
p1, p2, p3 = FoldMan(), FoldMan(), FoldMan()
e.register_player("uuid1", p1)
e.register_player("uuid2", p2)
e.register_player("uuid3", p3)
players_info = { 
    "a": { "name": "hoge", "stack": 100 },
     "b": { "name": "fuga", "stack": 100},
     "c": { "name": "boo", "stack": 100 } 
}
state = e.generate_initial_game_state(players_info)    # <= new method
state, events = e.start_new_round(state)
e.generate_possible_actions(state)  # <= new method
# returns => [{'action': 'fold', 'amount': 0}, {'action': 'call', 'amount': 10}, {'action': 'raise', 'amount': {'max': 90, 'min': 15}}]
state, events = e.apply_action("call", 10)
state, events = e.run_until_round_finish(state)
```