### PR TITLE
Fix bug which asks to player who don't need to declare action

### DIFF
--- a/pypokerengine/engine/round_manager.py
+++ b/pypokerengine/engine/round_manager.py
@@ -183,9 +183,14 @@ class RoundManager:
   def __is_everyone_agreed(self, state):
     self.__agree_logic_bug_catch(state)
     players = state["table"].seats.players
+    next_player_pos = state["table"].next_ask_waiting_player_pos(state["next_player"])
+    next_player = players[next_player_pos] if next_player_pos != "not_found" else None
     max_pay = max([p.paid_sum() for p in players])
     everyone_agreed = len(players) == len([p for p in players if self.__is_agreed(max_pay, p)])
-    return everyone_agreed or state["table"].seats.count_active_players() == 1
+    lonely_player = state["table"].seats.count_active_players() == 1
+    no_need_to_ask = state["table"].seats.count_ask_wait_players() == 1 and\
+            next_player and next_player.is_waiting_ask() and next_player.paid_sum() == max_pay
+    return everyone_agreed or lonely_player or no_need_to_ask
 
   @classmethod
   def __agree_logic_bug_catch(self, state):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'PyPokerEngine',
-    version = '0.1.1',
+    version = '0.1.2',
     author = 'ishikota',
     author_email = 'ishikota086@gmail.com',
     description = 'Poker engine for poker AI development in Python ',

--- a/tests/pypokerengine/engine/round_manager_test.py
+++ b/tests/pypokerengine/engine/round_manager_test.py
@@ -311,6 +311,31 @@ class RoundManagerTest(BaseUnitTest):
     self.eq("uuid1", msg[-1][0])
     self.eq(Const.Street.PREFLOP, state["street"])
 
+  def test_everyone_agree_logic_regression(self):
+    players = [Player("uuid%d" % i, 100) for i in range(4)]
+    players[0].stack = 150
+    players[1].stack = 150
+    players[2].stack = 50
+    players[3].stack = 50
+    deck = Deck(cheat=True, cheat_card_ids=range(1,53))
+    table = Table(cheat_deck=deck)
+    for player in players: table.seats.sitdown(player)
+    table.dealer_btn = 3
+    table.set_blind_pos(0, 1)
+
+    state, _ = RoundManager.start_new_round(1, 5, 0, table)
+    state, _ = RoundManager.apply_action(state, "raise", 15)
+    state, _ = RoundManager.apply_action(state, "raise", 20)
+    state, _ = RoundManager.apply_action(state, "raise", 25)
+    state, _ = RoundManager.apply_action(state, "raise", 30)
+    state, _ = RoundManager.apply_action(state, "raise", 50)
+    state, _ = RoundManager.apply_action(state, "call", 50)
+    state, _ = RoundManager.apply_action(state, "raise", 125)
+    state, _ = RoundManager.apply_action(state, "call", 125)
+    state, _ = RoundManager.apply_action(state, "fold", 0)
+    state, _ = RoundManager.apply_action(state, "fold", 0)
+    self.eq(Const.Street.FINISHED, state["street"])
+
   def test_deepcopy_state(self):
     table = self.__setup_table()
     original = RoundManager._RoundManager__gen_initial_state(2, 5, table)


### PR DESCRIPTION
### how to reproduce bug situation
p1.stack = $150
p2.stack = $150
p3.stack = $50
p4.stack = $50

**preflop**
p1 => pay $5 for small_blind
p2 => pay $10 for big blind
p3 => raise $15
p4 => raise $20
p1 => raise $25
p2 => raise $30
p3 => allin $50
p4 => allin $50
p1 => raise $125
p2 => call $125

**flop**
p1 => fold
p2 asked action <= [ Bug situation occurred ]

p2 is not declared action in flop but now he is only active player.
So dealer should not ask action to p2 (because p2 must be call)

But current implementation asks to p2 in such situation.
And if p2 declares *fold* action then crashes.
The reason of crash is that there is no player to receive main pot.
(player who paid $125 can receive main pot but both of eligible players(p1 and p2) is folded)