### PR TITLE
Fix blind update logic of emulator

### DIFF
--- a/pypokerengine/api/emulator.py
+++ b/pypokerengine/api/emulator.py
@@ -155,8 +155,11 @@ class Emulator(object):
 
 
 def update_blind_level(ante, sb_amount, round_count, blind_structure):
-    if blind_structure.has_key(round_count):
-        update_info = blind_structure[round_count]
+    level_thresholds = sorted(blind_structure.keys())
+    current_level_pos = [r <= round_count for r in level_thresholds].count(True)-1
+    if current_level_pos != -1:
+        current_level_key = level_thresholds[current_level_pos]
+        update_info = blind_structure[current_level_key]
         ante, sb_amount = update_info["ante"], update_info["small_blind"]
     return ante, sb_amount
 

--- a/tests/pypokerengine/api/emulator_test.py
+++ b/tests/pypokerengine/api/emulator_test.py
@@ -58,6 +58,36 @@ class EmulatorTest(BaseUnitTest):
         self.eq(0, game_state["table"].seats.players[0].stack)
         self.eq(80, game_state["table"].seats.players[1].stack)
 
+    def test_blind_structure_update(self):
+        self.emu.set_game_rule(2, 8, 5, 3)
+        p1, p2 = FoldMan(), FoldMan()
+        self.emu.register_player("uuid-1", p1)
+        self.emu.register_player("uuid-2", p2)
+        blind_structure = {
+                3: { "ante": 5, "small_blind": 10 },
+                5: {"ante": 10, "small_blind": 20 }
+                }
+        self.emu.set_blind_structure(blind_structure)
+        players_info = {
+                "uuid-1": { "name": "hoge", "stack": 100 },
+                "uuid-2": { "name": "fuga", "stack": 100 }
+                }
+        state = self.emu.generate_initial_game_state(players_info)
+        self.eq(5, state["small_blind_amount"])
+        state, _ = self.emu.start_new_round(state)
+        state, _ = self.emu.apply_action(state, "fold")
+        self.eq(5, state["small_blind_amount"])
+        state, _ = self.emu.apply_action(state, "fold")
+        self.eq(5, state["small_blind_amount"])
+        state, _ = self.emu.apply_action(state, "fold")
+        self.eq(10, state["small_blind_amount"])
+        state, _ = self.emu.apply_action(state, "fold")
+        self.eq(10, state["small_blind_amount"])
+        state, _ = self.emu.apply_action(state, "fold")
+        self.eq(20, state["small_blind_amount"])
+        state, _ = self.emu.apply_action(state, "fold")
+        self.eq(20, state["small_blind_amount"])
+
     def test_apply_action(self):
         game_state = restore_game_state(TwoPlayerSample.round_state)
         game_state = attach_hole_card_from_deck(game_state, "tojrbxmkuzrarnniosuhct")


### PR DESCRIPTION
original issue https://github.com/ishikota/PyPokerEngine/issues/46

Fixed logic of blind update in emulator.

**before**
```
#initial_ante = 0
#initial_small_blind = 5
#blind_structure = { 2: { "ante": 5, "small_blind": 10 } }
round2_start_state = self.emu.start_new_round(round1_finished_state)
# round2_start_state["small_blind_amount"] => 10
# ...
round3_start_state = self.emu.start_new_round(round2_finished_state)
# round3_start_state["small_blind_amount"] => 5 (it backs to initial blind amount)
```

**after**
```
round2_start_state = self.emu.start_new_round(round1_finished_state)
# round2_start_state["small_blind_amount"] => 10
round3_start_state = self.emu.start_new_round(round2_finished_state)
# round3_start_state["small_blind_amount"] => 10 ( OK!! )
```