### PR TITLE
Do not take ate into account when first action

### DIFF
--- a/pypokerengine/engine/player.py
+++ b/pypokerengine/engine/player.py
@@ -78,7 +78,7 @@ class Player:
     self.pay_info = PayInfo()
 
   def paid_sum(self):
-    pay_history = [h for h in self.action_histories if h["action"] != "FOLD"]
+    pay_history = [h for h in self.action_histories if h["action"] not in ["FOLD", "ANTE"]]
     last_pay_history = pay_history[-1] if len(pay_history)!=0 else None
     return last_pay_history["amount"] if last_pay_history else 0
 

--- a/tests/pypokerengine/engine/player_test.py
+++ b/tests/pypokerengine/engine/player_test.py
@@ -150,6 +150,18 @@ class PlayerTest(BaseUnitTest):
     self.assertIsNone(self.player.round_action_histories[Const.Street.PREFLOP])
     self.eq(0, len(self.player.action_histories))
 
+  def test_paid_sum(self):
+    self.eq(0, self.player.paid_sum())
+    self.player.add_action_history(Const.Action.BIG_BLIND, sb_amount=5)
+    self.eq(10, self.player.paid_sum())
+    self.player.clear_action_histories()
+    self.eq(0, self.player.paid_sum())
+    self.player.add_action_history(Const.Action.ANTE, 3)
+    self.eq(0, self.player.paid_sum())
+    self.player.add_action_history(Const.Action.BIG_BLIND, sb_amount=5)
+    self.eq(10, self.player.paid_sum())
+
+
   def test_serialization(self):
     player = self.__setup_player_for_serialization()
     serial = player.serialize()


### PR DESCRIPTION
original issue : https://github.com/ishikota/PyPokerEngine/issues/45

**before**
when p1 declare *RAISE 15* then player should pay 15 even if he already paid ante.
But p1 only pays 10 (15 - ante)
```
-- hole card --
 hole card : ['SJ', 'CK']
-- valid actions --
 fold, call:15, raise: [20, 95]
-- round state --
 Dealer Btn : p1 
 Street : preflop
 Community Card : []
 Pot : main = 40, side = []  <= pot should be 45
 Players
 0 : p1 (nrwbogvakciqwrmpowupkk) => state : participating, stack : 85
 1 : p2 (rcvyscrdwwxrkxqpsoaylj) => state : participating, stack : 90 <= SB, CURRENT
 2 : p3 (rxwhwxhnkftxvedsfhuoaj) => state : participating, stack : 85 <= BB
-- action histories --
  preflop
    {'action': 'ANTE', 'player': 'p2 (uuid=rcvyscrdwwxrkxqpsoaylj)', 'amount': 5}
    {'action': 'ANTE', 'player': 'p3 (uuid=rxwhwxhnkftxvedsfhuoaj)', 'amount': 5}
    {'action': 'ANTE', 'player': 'p1 (uuid=nrwbogvakciqwrmpowupkk)', 'amount': 5}
    {'action': 'SMALLBLIND', 'player': 'p2 (uuid=rcvyscrdwwxrkxqpsoaylj)', 'amount': 5, 'add_amount': 5}
    {'action': 'BIGBLIND', 'player': 'p3 (uuid=rxwhwxhnkftxvedsfhuoaj)', 'amount': 10, 'add_amount': 5}
    {'add_amount': 5, 'paid': 10, 'player': 'p1 (uuid=nrwbogvakciqwrmpowupkk)', 'amount': 15, 'action': 'RAISE'}   <= paid should be 15
```

**after**
```
-- hole card --
 hole card : ['C3', 'SA']
-- valid actions --
 fold, call:15, raise: [20, 95]
-- round state --
 Dealer Btn : p1 
 Street : preflop
 Community Card : []
 Pot : main = 45, side = []
 Players
 0 : p1 (wmhucuzwphitsxcctkkazh) => state : participating, stack : 80
 1 : p2 (npckuwxtnckddwrmjihafi) => state : participating, stack : 90 <= SB, CURRENT
 2 : p3 (frhmepctyubktqtudupvar) => state : participating, stack : 85 <= BB
-- action histories --
  preflop
    {'action': 'ANTE', 'player': 'p2 (uuid=npckuwxtnckddwrmjihafi)', 'amount': 5}
    {'action': 'ANTE', 'player': 'p3 (uuid=frhmepctyubktqtudupvar)', 'amount': 5}
    {'action': 'ANTE', 'player': 'p1 (uuid=wmhucuzwphitsxcctkkazh)', 'amount': 5}
    {'action': 'SMALLBLIND', 'player': 'p2 (uuid=npckuwxtnckddwrmjihafi)', 'amount': 5, 'add_amount': 5}
    {'action': 'BIGBLIND', 'player': 'p3 (uuid=frhmepctyubktqtudupvar)', 'amount': 10, 'add_amount': 5}
    {'add_amount': 5, 'paid': 15, 'player': 'p1 (uuid=wmhucuzwphitsxcctkkazh)', 'amount': 15, 'action': 'RAISE'}
==============================================
```