### PR TITLE
Fix the bug of remove player before game

### DIFF
--- a/pypokerengine/api/emulator.py
+++ b/pypokerengine/api/emulator.py
@@ -172,6 +172,10 @@ def exclude_short_of_money_players(table, ante, sb_amount):
 
 def _steal_money_from_poor_player(table, ante, sb_amount):
     players = table.seats.players
+    # exclude player who cannot pay ante
+    for player in [p for p in players if p.stack < ante]: player.stack = 0
+    if players[table.dealer_btn].stack == 0: table.shift_dealer_btn()
+
     search_targets = players + players + players
     search_targets = search_targets[table.dealer_btn+1:table.dealer_btn+1+len(players)]
     # exclude player who cannot pay small blind

--- a/pypokerengine/engine/dealer.py
+++ b/pypokerengine/engine/dealer.py
@@ -111,6 +111,10 @@ class Dealer:
 
   def __steal_money_from_poor_player(self, table, ante, sb_amount):
     players = table.seats.players
+    # exclude player who cannot pay ante
+    for player in [p for p in players if p.stack < ante]: player.stack = 0
+    if players[table.dealer_btn].stack == 0: table.shift_dealer_btn()
+
     search_targets = players + players + players
     search_targets = search_targets[table.dealer_btn+1:table.dealer_btn+1+len(players)]
     # exclude player who cannot pay small blind

--- a/tests/pypokerengine/engine/dealer_test.py
+++ b/tests/pypokerengine/engine/dealer_test.py
@@ -116,6 +116,20 @@ class DealerTest(BaseUnitTest):
     result = dealer.start_game(4)
     self.eq(fetch_stacks(result), [1060, 0, 0, 1025, 0])
 
+  def test_exclude_short_of_money_player_when_ante_on2(self):
+    dealer = Dealer(5, 100, 20)
+    algos = [FoldMan() for _ in range(3)]
+    [dealer.register_player("algo-%d" % idx, algo) for idx, algo in enumerate(algos)]
+    dealer.table.dealer_btn = 2
+    # initialize stack
+    for idx, stack in enumerate([30, 25, 19]):
+      dealer.table.seats.players[idx].stack = stack
+    fetch_stacks = lambda res: [p["stack"] for p in res["message"]["game_information"]["seats"]]
+
+    result = dealer.start_game(1)
+    self.eq([55, 0, 0], fetch_stacks(result))
+
+
   def test_only_one_player_is_left(self):
     algos = [FoldMan() for _ in range(2)]
     [self.dealer.register_player(name, algo) for name, algo in zip(["hoge", "fuga"], algos)]


### PR DESCRIPTION
### Bug situation
RoundManager failed to correct ante from player.
```
ValueError: Failed to collect 1000 chips. Because he has only 475 chips
```
The player who cannot pay forced bet should be removed before start the game by dealer.
But dealer didn't remove him.

### How to reproduce bug situation
sb_amount = 5, ante = 20
p1.stack = 100 (small blind)
p2.stack = 100 (big blind)
p3.stack = 19 (dealer button)

`dealer.__exclude_short_of_money_players` method doesn't disable p3.
So RoundManager try to correct ante from p3 and crashes.
